### PR TITLE
Fix watcher race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "bin": "./bin/index.js",
   "scripts": {
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "clean": "rm -rf lib",
     "dev": "npm run build -- -w",
     "build": "npm run clean && tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ function main(): void {
         : console.info(`Watching for files...`);
 
     const srcWatcher = chokidar.watch('src');
+    const endWatchDebounced = pDebounce(async () => srcWatcher.close(), 10);
 
     srcWatcher.on('add', async (path: string) => {
         const destPath = await compile(path);
@@ -121,8 +122,8 @@ function main(): void {
             await transform(destPath);
         }
 
-        // Don't continue watching. This is safe if called multiple times.
-        IS_PRODUCTION_MODE && srcWatcher.close();
+        // Don't continue watching.
+        IS_PRODUCTION_MODE && endWatchDebounced();
     });
 
     if (IS_PRODUCTION_MODE) return;


### PR DESCRIPTION
CI revealed a race condition because it runs a bit slower than my local setup. The watcher was ending too early and wasn't able to compile all existing files.