### PR TITLE
Fix build race conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
   },
   "dependencies": {
     "chokidar": "^3.3.1",
-    "p-debounce": "^2.1.0",
+    "glob": "^7.1.6",
+    "p-limit": "^2.2.2",
     "snowpack": "^1.0.5"
   },
   "devDependencies": {
     "@jakedeichert/eslint-config": "^4.0.5",
     "@types/babel__core": "^7.1.3",
+    "@types/glob": "^7.1.1",
     "@types/node": "^13.1.8",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import * as path from 'path';
 import * as svelte from 'svelte/compiler';
 import * as chokidar from 'chokidar';
 import * as babel from '@babel/core';
-import pDebounce from 'p-debounce';
+import * as glob from 'glob';
+import pLimit from 'p-limit';
 
 const exec = util.promisify(execSync);
 
@@ -78,7 +79,7 @@ async function transform(destPath: string): Promise<void> {
 
 // Only needs to run during the initial compile cycle. If a developer adds a new package dependency,
 // they should restart svelvet.
-const snowpackDebounced = pDebounce(async () => {
+const snowpack = async (): Promise<void> => {
     const maybeOptimize = IS_PRODUCTION_MODE ? '--optimize' : '';
 
     console.info(`\nBuilding web_modules with snowpack...`);
@@ -103,36 +104,55 @@ const snowpackDebounced = pDebounce(async () => {
         console.error(err);
         console.log('');
     }
-}, 50);
+};
 
-function main(): void {
-    IS_PRODUCTION_MODE
-        ? console.info(`Building in production mode...`)
-        : console.info(`Watching for files...`);
+async function initialBuild(): Promise<void> {
+    if (IS_PRODUCTION_MODE) console.info(`Building in production mode...`);
 
-    const srcWatcher = chokidar.watch('src');
-    const endWatchDebounced = pDebounce(async () => srcWatcher.close(), 10);
+    const concurrentCompilationLimit = pLimit(8);
 
-    srcWatcher.on('add', async (path: string) => {
-        const destPath = await compile(path);
-
-        if (destPath) {
-            // Need to run (only once) before transforming the import paths, or else it will fail.
-            await snowpackDebounced();
-            await transform(destPath);
-        }
-
-        // Don't continue watching.
-        IS_PRODUCTION_MODE && endWatchDebounced();
+    const srcFiles = glob.sync('src/**', {
+        nodir: true,
     });
 
-    if (IS_PRODUCTION_MODE) return;
+    // Compile all source files with svelte.
+    const destFiles = await Promise.all(
+        srcFiles.map(srcPath =>
+            concurrentCompilationLimit(async () => {
+                const destPath = await compile(srcPath);
+                return destPath;
+            })
+        )
+    );
+
+    // Need to run (only once) before transforming the import paths, or else it will fail.
+    await snowpack();
+
+    // Transform all js files with babel.
+    await Promise.all(
+        destFiles.map(destPath =>
+            concurrentCompilationLimit(async () => {
+                if (!destPath) return;
+                await transform(destPath);
+            })
+        )
+    );
+}
+
+function startWatchMode(): void {
+    console.info(`Watching for files...`);
+    const srcWatcher = chokidar.watch('src');
 
     srcWatcher.on('change', async (path: string) => {
         const destPath = await compile(path);
         if (!destPath) return;
         transform(destPath);
     });
+}
+
+async function main(): Promise<void> {
+    await initialBuild();
+    if (!IS_PRODUCTION_MODE) startWatchMode();
 }
 
 main();


### PR DESCRIPTION
### Which issue does this fix?
<!-- Replace {ISSUE} with the issue number you've fixed -->

Closes #5 



### Describe the solution

Using glob to get all src files up front, compile them with a concurrency limit, then run snowpack and babel transform last.

This removes all debouncing which was the cause of those race conditions.

