### PR TITLE
Only delete files inside dist/ in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Add a few simple scripts as seen [here][basic_example_package]:
     "build": "NODE_ENV=production npm run dev",
 
     // Remove generated files for a clean build
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist/*",
 
     // An example of how to serve dist locally (requires "npm install serve --save-dev")
     "serve": "serve --listen 8080 --single dist"


### PR DESCRIPTION
### Which issue does this fix?
deleting the whole `dist/` folder (as exampled in README) will remove watches done to that folder. if using a http server that watches for files to refresh (like `live-server`) it will stop watching files and require to restart the server.

### Describe the solution
instead of deleting `dist`, delete `dist/*`
