### PR TITLE
examples/basic: use svelvet ^0.2.0

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,6 +10,6 @@
     "svelte": "^3.7.1"
   },
   "devDependencies": {
-    "svelvet": "^0.1.1"
+    "svelvet": "^0.2.0"
   }
 }


### PR DESCRIPTION
This upgrades the example to use the newest release.

Motivation: I was confused why the basic example was not serving anything on localhost, when according to the README it should have.

Note: npm semver `^` caret ranges fix the left-most non-zero digit. The example will need updating again when you release 0.3.0, which may or may not be what you want.
