### PR TITLE
Use rimraf instead of `rm -rf`

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,12 +4,13 @@
   "scripts": {
     "dev": "npm run clean && svelvet",
     "build": "NODE_ENV=production npm run dev",
-    "clean": "rm -rf dist"
+    "clean": "rimraf dist"
   },
   "dependencies": {
     "svelte": "^3.7.1"
   },
   "devDependencies": {
-    "svelvet": "^0.2.0"
+    "svelvet": "^0.2.0",
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
Use rimraf for windows compatibality

### Which issue does this fix?
Template is incompatible with Windows (`rm -f` is non-existent).


### Describe the solution
Use `rimraf` package which is compatible with both macOS/Linux/Windows