### PR TITLE
Auto delete dist directory on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,10 @@ Add a few simple scripts as seen [here][basic_example_package]:
 "scripts": {
     // This starts svelvet in watch mode and runs snowpack once to generate dist/web_modules.
     // It also starts a live reloading dev server on localhost:8080
-    "dev": "npm run clean && svelvet",
+    "dev": "svelvet",
 
     // This builds the dist directory optimized for production with snowpack
-    "build": "NODE_ENV=production npm run dev",
-
-    // Remove generated files for a clean build
-    "clean": "rm -rf dist/*"
+    "build": "NODE_ENV=production svelvet"
 },
 ~~~
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,9 +2,8 @@
   "name": "svelvet-example-basic",
   "private": true,
   "scripts": {
-    "dev": "npm run clean && svelvet",
-    "build": "NODE_ENV=production npm run dev",
-    "clean": "rm -rf dist"
+    "dev": "svelvet",
+    "build": "NODE_ENV=production svelvet"
   },
   "dependencies": {
     "svelte": "^3.7.1"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chokidar": "^3.3.1",
     "glob": "^7.1.6",
     "p-limit": "^2.2.2",
+    "rimraf": "^3.0.2",
     "servor": "^3.1.0",
     "snowpack": "1.2.0",
     "terser": "^4.6.3"
@@ -29,6 +30,7 @@
     "@types/babel__core": "^7.1.3",
     "@types/glob": "^7.1.1",
     "@types/node": "^13.1.8",
+    "@types/rimraf": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
     "prettier": "^1.16.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import * as glob from 'glob';
 import * as terser from 'terser';
 import pLimit from 'p-limit';
 import * as servor from 'servor';
+import * as rimraf from 'rimraf';
 
 const exec = util.promisify(execSync);
 
@@ -30,6 +31,11 @@ const BABEL_CONFIG = existsSync('./babel.config.js')
               ],
           ],
       };
+
+async function cleanDist(): Promise<void> {
+    if (process.argv.includes('--no-clean')) return;
+    await new Promise(resolve => rimraf('dist', resolve));
+}
 
 async function compile(
     srcPath: string
@@ -274,6 +280,7 @@ async function startDevServer(): Promise<void> {
 }
 
 async function main(): Promise<void> {
+    await cleanDist();
     await initialBuild();
     if (IS_PRODUCTION_MODE) return;
     startWatchMode();

--- a/tests/snapshot-babel-override/package.json
+++ b/tests/snapshot-babel-override/package.json
@@ -2,9 +2,8 @@
   "name": "svelvet-test",
   "private": true,
   "scripts": {
-    "dev": "npm run clean && svelvet",
-    "build": "NODE_ENV=production npm run dev",
-    "clean": "rm -rf dist"
+    "dev": "svelvet",
+    "build": "NODE_ENV=production svelvet"
   },
   "dependencies": {
     "svelte": "3.18.1"

--- a/tests/snapshot/package.json
+++ b/tests/snapshot/package.json
@@ -2,9 +2,8 @@
   "name": "svelvet-test",
   "private": true,
   "scripts": {
-    "dev": "npm run clean && svelvet",
-    "build": "NODE_ENV=production npm run dev",
-    "clean": "rm -rf dist"
+    "dev": "svelvet",
+    "build": "NODE_ENV=production svelvet"
   },
   "dependencies": {
     "svelte": "3.18.1"


### PR DESCRIPTION
### Which issue does this fix?
<!-- Replace {ISSUE} with the issue number you've fixed -->

Closes #41 



### Describe the solution

Automatically deletes the dist directory on build so that the user doesn't need a `clean` command anymore. 

Also added a `--no-clean` option for people that want more control over their `dist` directory.
