### PR TITLE
Call node explicitly in order to run snowpack on Windows, too

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ const snowpack = async (): Promise<void> => {
         );
 
         const { stdout, stderr } = await exec(
-            `${snowpackLocation} --include 'dist/**/*' --dest dist/web_modules ${maybeOptimize}`
+            `node ${snowpackLocation} --include 'dist/**/*' --dest dist/web_modules ${maybeOptimize}`
         );
 
         // TODO: hide behind --verbose flag


### PR DESCRIPTION
### Which issue does this fix?

Closes #40 


### Describe the solution

The change forces the snowpack 'binary' js file to be run with node, always. Running it 'as a file' works on POSIX-ish environments as it detects the actual binary to run the script with from the hashbang but Windows uses extensions to determine this and node is not typically set up as the default interpreter for .js files. 
