### PR TITLE
Prevent external imports from triggering snowpack web_module regeneration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -223,8 +223,10 @@ async function checkForNewWebModules(
         const importPath = transformedSource.substring(meta.s, meta.e);
         const notRelative = !importPath.startsWith('.');
         const notAbsolute = !importPath.startsWith('/');
+        const notHttp = !importPath.startsWith('http://');
+        const notHttps = !importPath.startsWith('https://');
         // Must be a node_module that snowpack didn't see before
-        return notRelative && notAbsolute;
+        return notRelative && notAbsolute && notHttp && notHttps;
     });
 
     return foundMissingWebModule;


### PR DESCRIPTION
### Describe the solution

There was a bug when checking for missing web_modules where external http imports would cause snowpack to regen web_modules needlessly. 

This fixes it by ignoring http/https imports.
