### PR TITLE
fix(windows): normalize incoming paths to getDestPath

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,9 @@ async function copyFile(srcPath: string): Promise<void> {
 }
 
 function getDestPath(srcPath: string): string {
-    return path.normalize(srcPath).replace(new RegExp(`^src\\${path.sep}`), `dist${path.sep}`);
+    return path
+        .normalize(srcPath)
+        .replace(new RegExp(`^src\\${path.sep}`), `dist${path.sep}`);
 }
 
 // Update the import paths to correctly point to web_modules.

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ async function copyFile(srcPath: string): Promise<void> {
 }
 
 function getDestPath(srcPath: string): string {
-    return srcPath.replace(new RegExp(`^src\\${path.sep}`), `dist${path.sep}`);
+    return path.normalize(srcPath).replace(new RegExp(`^src\\${path.sep}`), `dist${path.sep}`);
 }
 
 // Update the import paths to correctly point to web_modules.


### PR DESCRIPTION
### Which issue does this fix?

Closes #46 

### Describe the solution

Originally, the path separator/resolution issue was fixed in the watch mode but I missed that the fix indeed caused a regression on Windows during the initial build - my bad!

The regression was due to the glob package returning paths with forward slashes regardless of the platform (as [documented](https://github.com/isaacs/node-glob#windows)), causing the initial build to fail on Windows and crashing when the build ended up in the wrong place (src/). Previously, this step would have worked as forward slashes *were* getting replaced correctly but backslashes returned through watch were not.

This solution uses Node standard library [path.normalize](https://nodejs.org/api/path.html#path_path_normalize_path) to normalize the input paths to getDestPath, in order to always have the OS-specific path to do the regexp magic with. 

I guess in the future, using the path package might open up a door to get rid of the regexp altogether and making the path generation more resilient? 