### PR TITLE
Let babel know the absolute file path of the file currently being processed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,10 +152,10 @@ async function transform(
     try {
         const source = await fs.readFile(destPath, 'utf8');
 
-        let transformed = (await babel.transformAsync(
-            source,
-            BABEL_CONFIG
-        )) as babel.BabelFileResult;
+        let transformed = (await babel.transformAsync(source, {
+            ...BABEL_CONFIG,
+            filename: destPath,
+        })) as babel.BabelFileResult;
 
         if (checkModules) {
             const foundMissingWebModule = await checkForNewWebModules(


### PR DESCRIPTION


### Which issue does this fix?
<!-- Replace {ISSUE} with the issue number you've fixed -->

Closes #58



### Describe the solution

This allows babel plugins to understand what the file's location is when processing it. This actually fixes a bug with babel-plugin-inline-json-import as described in https://github.com/jakedeichert/svelvet/issues/58.

Docs: https://babeljs.io/docs/en/options#filename
