### PR TITLE
Add --production flag for better cross-platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add a few simple scripts as seen [here][basic_example_package]:
     "dev": "svelvet",
 
     // This builds the public/dist directory optimized for production with snowpack
-    "build": "NODE_ENV=production svelvet"
+    "build": "svelvet --production"
 },
 ~~~
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "svelvet",
-    "build": "NODE_ENV=production svelvet"
+    "build": "svelvet --production"
   },
   "dependencies": {
     "svelte": "^3.7.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import rimraf from 'rimraf';
 import { init as initEsModuleLexer, parse } from 'es-module-lexer';
 import throttle from 'lodash.throttle';
 
-const IS_PRODUCTION_MODE = process.env.NODE_ENV === 'production';
+const IS_PRODUCTION_MODE = process.argv.includes('--production');
 const BABEL_CONFIG = loadBabelConfig();
 const SVELTE_PREPROCESSOR_CONFIG = loadSveltePreprocessors();
 

--- a/tests/snapshot-babel-override/package.json
+++ b/tests/snapshot-babel-override/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "svelvet",
-    "build": "NODE_ENV=production svelvet"
+    "build": "svelvet --production"
   },
   "dependencies": {
     "svelte": "3.18.1"

--- a/tests/snapshot-preprocessors/package.json
+++ b/tests/snapshot-preprocessors/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "svelvet --preprocess my-preprocessors.js",
-    "build": "NODE_ENV=production svelvet --preprocess my-preprocessors.js"
+    "build": "svelvet --production --preprocess my-preprocessors.js"
   },
   "dependencies": {
     "svelte": "3.18.1"

--- a/tests/snapshot-snowpack-config/package.json
+++ b/tests/snapshot-snowpack-config/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "svelvet",
-    "build": "NODE_ENV=production svelvet"
+    "build": "svelvet --production"
   },
   "dependencies": {
     "svelte": "3.18.1",

--- a/tests/snapshot/package.json
+++ b/tests/snapshot/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "svelvet",
-    "build": "NODE_ENV=production svelvet"
+    "build": "svelvet --production"
   },
   "dependencies": {
     "svelte": "3.18.1"


### PR DESCRIPTION
### Which issue does this fix?
<!-- Replace {ISSUE} with the issue number you've fixed -->

Closes #62



### Describe the solution

🚨 Breaking Change 🚨

`NODE_ENV=production svelvet` does not work on certain platforms/shells. For example, in Windows powershell you have to write `$env:NODE_ENV="production"`.

Replacing that with a `--production` flag so that calling svelvet on all platforms is the same which means less issues and documentation :)


### TODO

- [ ] release as a breaking change
- [ ] include migration guide in release notes
- [ ] newly related NODE_ENV usage https://github.com/jakedeichert/svelvet/issues/69#issuecomment-602098919