### PR TITLE
Fix missing web_module check for dynamic imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,10 @@ async function checkForNewWebModules(
 
     // Search for new import paths that snowpack hasn't generated yet
     const foundMissingWebModule = esImports.some((meta) => {
-        const importPath = transformedSource.substring(meta.s, meta.e);
+        // Replace quotes due to issue with dynamic imports starting with them.
+        const importPath = transformedSource
+            .substring(meta.s, meta.e)
+            .replace(/['"]/g, '');
         const notRelative = !importPath.startsWith('.');
         const notAbsolute = !importPath.startsWith('/');
         const notHttp = !importPath.startsWith('http://');


### PR DESCRIPTION

### Describe the solution

When a svelte file contained a dynamic import like `const HomePage = () => import('/pages/Home/index');`, the snowpack check for missing web_modules would always fail because `es-module-lexer` seems to have the paths wrapped in quotes I guess.
